### PR TITLE
Rescue 1.9

### DIFF
--- a/bsoft/__init__.py
+++ b/bsoft/__init__.py
@@ -29,7 +29,7 @@ import os
 import pwem
 from pyworkflow.utils import Environ
 
-from bsoft.constants import BSOFT_HOME, V2_0_7, V1_9_0
+from bsoft.constants import BSOFT_HOME, V2_0_7, V1_9_0, BSOFT
 
 __version__ = '3.0.5'
 _logo = "bsoft_logo.png"
@@ -43,7 +43,7 @@ class Plugin(pwem.Plugin):
 
     @classmethod
     def _defineVariables(cls):
-        cls._defineEmVar(BSOFT_HOME, 'bsoft-2.0.7')
+        cls._defineEmVar(BSOFT_HOME, BSOFT + "-" + V2_0_7)
 
     @classmethod
     def getEnviron(cls, bsoftVersion=None):
@@ -63,7 +63,7 @@ class Plugin(pwem.Plugin):
     @classmethod
     def getHomeFromVersion(self, bsoftVersion):
 
-        return Plugin.getHome() if bsoftVersion is None else os.path.join(pwem.Config.EM_ROOT, bsoftVersion)
+        return Plugin.getHome() if bsoftVersion is None else os.path.join(pwem.Config.EM_ROOT, BSOFT + "-" + bsoftVersion)
 
     @classmethod
     def getProgram(cls, program, bsoftVersion=None):
@@ -73,12 +73,12 @@ class Plugin(pwem.Plugin):
     @classmethod
     def defineBinaries(cls, env):
 
-        env.addPackage('bsoft', version='1.9.0',
+        env.addPackage(BSOFT, version='1.9.0',
                        tar='bsoft1_9_0_Fedora_20.tgz',
                        default=True)
 
-        env.addPackage('bsoft', version='2.0.7',
-			            url="https://lsbr.niams.nih.gov/bsoft/bsoft2_0_7_CentOS_7.7.1908.tgz",
-                        buildDir = "bsoft",
-                        default=True)
+        env.addPackage(BSOFT, version='2.0.7',
+                       url="https://lsbr.niams.nih.gov/bsoft/bsoft2_0_7_CentOS_7.7.1908.tgz",
+                       buildDir = "bsoft",
+                       default=True)
 

--- a/bsoft/__init__.py
+++ b/bsoft/__init__.py
@@ -63,7 +63,7 @@ class Plugin(pwem.Plugin):
     @classmethod
     def getHomeFromVersion(self, bsoftVersion):
 
-        return Plugin.getHome() if bsoftVersion is None else os.path.join(pwem.Config.EM_HOME, bsoftVersion)
+        return Plugin.getHome() if bsoftVersion is None else os.path.join(pwem.Config.EM_ROOT, bsoftVersion)
 
     @classmethod
     def getProgram(cls, program, bsoftVersion=None):

--- a/bsoft/__init__.py
+++ b/bsoft/__init__.py
@@ -29,9 +29,9 @@ import os
 import pwem
 from pyworkflow.utils import Environ
 
-from bsoft.constants import BSOFT_HOME, V2_0_7
+from bsoft.constants import BSOFT_HOME, V2_0_7, V1_9_0
 
-__version__ = '3.0.4'
+__version__ = '3.0.5'
 _logo = "bsoft_logo.png"
 _references = ['Heymann2007', 'Heymann2018']
 
@@ -46,25 +46,39 @@ class Plugin(pwem.Plugin):
         cls._defineEmVar(BSOFT_HOME, 'bsoft-2.0.7')
 
     @classmethod
-    def getEnviron(cls, xmippFirst=True):
-        """ Setup the environment variables needed to launch bsoft. """
+    def getEnviron(cls, bsoftVersion=None):
+        """ Setup the environment variables needed to launch bsoft.
+        :param bsoftVersion (optional) pass a version to be used,
+        otherwise will choose default value for BSOFT_HOME"""
         environ = Environ(os.environ)
-        pos = Environ.BEGIN if xmippFirst else Environ.END
+
+        home = cls.getHomeFromVersion(bsoftVersion)
+
         environ.update({
-            'PATH': os.path.join(Plugin.getHome(), 'bin'),
-            'BSOFT': Plugin.getHome()
-        }, position=pos)
+            'PATH': os.path.join(home, 'bin'),
+            'BSOFT': home
+        }, position=Environ.BEGIN)
         return environ
 
     @classmethod
-    def getProgram(cls, program):
+    def getHomeFromVersion(self, bsoftVersion):
+
+        return Plugin.getHome() if bsoftVersion is None else os.path.join(pwem.Config.EM_HOME, bsoftVersion)
+
+    @classmethod
+    def getProgram(cls, program, bsoftVersion=None):
         """ Return the program binary that will be used. """
-        cmd = cls.getHome('bin', program)
-        return str(cmd)
+        return os.path.join(cls.getHomeFromVersion(bsoftVersion),"bin", program)
 
     @classmethod
     def defineBinaries(cls, env):
+
+        env.addPackage('bsoft', version='1.9.0',
+                       tar='bsoft1_9_0_Fedora_20.tgz',
+                       default=True)
+
         env.addPackage('bsoft', version='2.0.7',
 			            url="https://lsbr.niams.nih.gov/bsoft/bsoft2_0_7_CentOS_7.7.1908.tgz",
                         buildDir = "bsoft",
                         default=True)
+

--- a/bsoft/constants.py
+++ b/bsoft/constants.py
@@ -30,6 +30,7 @@ BSOFT_HOME = 'BSOFT_HOME'
 
 # Supported Versions
 V2_0_7 = '2.0.7'
+V1_9_0 = '1.9.0'
 
 # Bfilter constants
 FILTER_MEDIAN = 0

--- a/bsoft/constants.py
+++ b/bsoft/constants.py
@@ -28,6 +28,8 @@ from collections import OrderedDict
 
 BSOFT_HOME = 'BSOFT_HOME'
 
+BSOFT = 'bsoft'
+
 # Supported Versions
 V2_0_7 = '2.0.7'
 V1_9_0 = '1.9.0'


### PR DESCRIPTION
Xmipp FSCQ does work only with Bsoft 1.9.0 for now
Current version 2.0.7 does not render the same results and needs more time to understand what is going on.
This installs bsoft 1.9.0 but still defaults to 2.0.7 and 1.9.0 is not among the supported versions. THis changes only support executing BSOFT 1.9.0 from another plugin (like xmipp) but not from the GUI. 